### PR TITLE
[Feat] JPA Entity 매핑! (#9) 

### DIFF
--- a/aenitto/build.gradle
+++ b/aenitto/build.gradle
@@ -31,6 +31,7 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+	testImplementation 'org.assertj:assertj-core:3.22.0'
 }
 
 tasks.named('test') {

--- a/aenitto/src/main/java/com/firefighter/aenitto/AenittoApplication.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/AenittoApplication.java
@@ -2,7 +2,9 @@ package com.firefighter.aenitto;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class AenittoApplication {
 

--- a/aenitto/src/main/java/com/firefighter/aenitto/common/namingStrategy/SnakeLowerCasePhysicalNamingStrategy.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/common/namingStrategy/SnakeLowerCasePhysicalNamingStrategy.java
@@ -1,0 +1,41 @@
+package com.firefighter.aenitto.common.namingStrategy;
+
+import org.hibernate.boot.model.naming.Identifier;
+import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
+import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
+
+public class SnakeLowerCasePhysicalNamingStrategy implements PhysicalNamingStrategy {
+    @Override
+    public Identifier toPhysicalCatalogName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(name);
+    }
+
+    @Override
+    public Identifier toPhysicalSchemaName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(name);
+    }
+
+    @Override
+    public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(name);
+    }
+
+    @Override
+    public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(name);
+    }
+
+    @Override
+    public Identifier toPhysicalColumnName(Identifier name, JdbcEnvironment jdbcEnvironment) {
+        return convertToSnakeCase(name);
+    }
+
+    private Identifier convertToSnakeCase(final Identifier identifier) {
+        final String regex = "([a-z])([A-Z])";
+        final String replacement = "$1_$2";
+        final String newName = identifier.getText()
+                .replaceAll(regex, replacement)
+                .toLowerCase();
+        return Identifier.toIdentifier(newName);
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CommonMission.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CommonMission.java
@@ -1,0 +1,29 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CommonMission {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "common_mission_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+
+    private LocalDate date;
+
+    @Builder
+    public CommonMission(LocalDate date) {
+        this.date = date;
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
@@ -14,6 +14,6 @@ import java.time.LocalDateTime;
 @EntityListeners({AuditingEntityListener.class})
 public abstract class CreationLog {
     @CreatedDate
-    @Column(name = "created_at", updatable = false)
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 }

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
@@ -1,0 +1,19 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners({AuditingEntityListener.class})
+public class CreationLog {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationLog.java
@@ -12,7 +12,7 @@ import java.time.LocalDateTime;
 @MappedSuperclass
 @Getter
 @EntityListeners({AuditingEntityListener.class})
-public class CreationLog {
+public abstract class CreationLog {
     @CreatedDate
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationModificationLog.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationModificationLog.java
@@ -1,0 +1,24 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@MappedSuperclass
+@Getter
+@EntityListeners({AuditingEntityListener.class})
+public abstract class CreationModificationLog {
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationModificationLog.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/CreationModificationLog.java
@@ -15,10 +15,10 @@ import java.time.LocalDateTime;
 @EntityListeners({AuditingEntityListener.class})
 public abstract class CreationModificationLog {
     @CreatedDate
-    @Column(name = "created_at", updatable = false)
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @LastModifiedDate
-    @Column(name = "updated_at")
+    @Column
     private LocalDateTime updatedAt;
 }

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/IndividualMission.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/IndividualMission.java
@@ -31,7 +31,7 @@ public class IndividualMission {
     @ColumnDefault(value = "false")
     private boolean fulfilled;
 
-    @Column(name = "fulfilled_at")
+    @Column
     private LocalDateTime fulfilledAt;
 
     @Builder

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/IndividualMission.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/IndividualMission.java
@@ -1,0 +1,42 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class IndividualMission {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "individual_mission_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "mission_id")
+    private Mission mission;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_room_id")
+    private MemberRoom memberRoom;
+
+    private LocalDate date;
+
+    @ColumnDefault(value = "false")
+    private boolean fulfilled;
+
+    @Column(name = "fulfilled_at")
+    private LocalDateTime fulfilledAt;
+
+    @Builder
+    public IndividualMission(LocalDate date) {
+        this.date = date;
+    }
+}
+

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
@@ -4,18 +4,21 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.GenericGenerator;
 
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Member extends CreationModificationLog {
-    @Id @GeneratedValue(strategy = GenerationType.AUTO)
-    @Column(name = "member_id")
-    private Long id;
+    @Id @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name = "uuid2", strategy = "uuid2")
+    @Column(name = "member_id", columnDefinition = "BINARY(225)")
+    private UUID id;
 
     private String nickname;
 

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
@@ -11,7 +11,7 @@ import java.util.ArrayList;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Member {
+public class Member extends CreationModificationLog {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_id")
     private String id;

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
@@ -1,0 +1,28 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Member {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "member_id")
+    private String id;
+
+    private String nickname;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
+    private List<MemberRoom> memberRooms = new ArrayList<>();
+
+    @Builder
+    public Member(String nickname) {
+        this.nickname = nickname;
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Member.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -14,7 +15,7 @@ import java.util.ArrayList;
 public class Member extends CreationModificationLog {
     @Id @GeneratedValue(strategy = GenerationType.AUTO)
     @Column(name = "member_id")
-    private String id;
+    private Long id;
 
     private String nickname;
 

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
@@ -30,6 +30,7 @@ public class MemberRoom extends CreationModificationLog {
 
     private boolean admin;
 
+    @Column(name = "color_idx")
     private int colorIdx;
 
     @Enumerated(value = EnumType.STRING)

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
@@ -1,0 +1,47 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberRoom extends CreationModificationLog {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "member_room_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    @OneToMany(mappedBy = "memberRoom")
+    private List<IndividualMission> individualMissions = new ArrayList<>();
+
+    private boolean admin;
+
+    private int colorIdx;
+
+    @Enumerated(value = EnumType.STRING)
+    private ParticipantRole role;
+
+    @Builder
+    public MemberRoom(boolean admin, int colorIdx) {
+        this.admin = admin;
+        this.colorIdx = colorIdx;
+    }
+
+    public boolean isAdmin() {
+        return this.admin;
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
@@ -30,7 +30,7 @@ public class MemberRoom extends CreationModificationLog {
 
     private boolean admin;
 
-    @Column(name = "color_idx")
+    @Column
     private int colorIdx;
 
     @Enumerated(value = EnumType.STRING)

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/MemberRoom.java
@@ -45,3 +45,4 @@ public class MemberRoom extends CreationModificationLog {
         return this.admin;
     }
 }
+

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Message.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Message.java
@@ -33,7 +33,7 @@ public class Message extends CreationLog {
     @ColumnDefault(value = "false")
     private boolean read;
 
-    @Column(name = "img_url")
+    @Column
     private String imgUrl;
 
     @Builder

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Message.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Message.java
@@ -1,0 +1,52 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Message extends CreationLog {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "message_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "sender_id")
+    private Member sender;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "receiver_id")
+    private Member receiver;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+
+    private String content;
+
+    @ColumnDefault(value = "false")
+    private boolean read;
+
+    @Column(name = "img_url")
+    private String imgUrl;
+
+    @Builder
+    public Message(String content, String imgUrl) {
+        this.content = content;
+        this.imgUrl = imgUrl;
+    }
+
+    public boolean didRead() {
+        return this.read;
+    }
+
+    public void readMessage() {
+        this.read = true;
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Mission.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Mission.java
@@ -1,0 +1,28 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Mission {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "mission_id")
+    private Long id;
+
+    private String content;
+
+    @Enumerated(value = EnumType.STRING)
+    private MissionType type;
+
+    @Builder
+    public Mission(String content, MissionType type) {
+        this.content = content;
+        this.type = type;
+    }
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/MissionType.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/MissionType.java
@@ -1,0 +1,6 @@
+package com.firefighter.aenitto.domain;
+
+public enum MissionType {
+    COMMON, INDIVIDUAL
+    ;
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/ParticipantRole.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/ParticipantRole.java
@@ -1,0 +1,5 @@
+package com.firefighter.aenitto.domain;
+
+
+public enum ParticipantRole {
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Relation.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Relation.java
@@ -1,0 +1,34 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Relation {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "relation_id")
+    private Long id;
+
+    /*
+    Manitto: 챙겨주는 사람
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manitto_id")
+    private Member manitto;
+
+    /*
+    Manittee : 챙김 받는 사람
+     */
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "manittee_id")
+    private Member manittee;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "room_id")
+    private Room room;
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Room.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Room.java
@@ -1,2 +1,60 @@
-package com.firefighter.aenitto.domain;public class Room {
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Room extends CreationModificationLog {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "room_id")
+    private Long id;
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
+    private List<MemberRoom> memberRooms = new ArrayList<>();
+
+    @OneToMany(mappedBy = "room", cascade = CascadeType.ALL)
+    private List<Relation> relations = new ArrayList<>();
+
+    private int capacity;
+
+    private String invitation;
+
+    @Enumerated(value = EnumType.STRING)
+    private RoomState state;
+
+    @ColumnDefault(value = "false")
+    private boolean deleted;
+
+    private LocalDate startDate;
+
+    private LocalDate endDate;
+
+    @Builder
+    public Room(int capacity, String invitation, RoomState state, String startDate, String endDate) {
+        this.capacity = capacity;
+        this.invitation = invitation;
+        this.state = state;
+        this.startDate = stringToLocalDate(startDate);
+        this.endDate = stringToLocalDate(endDate);
+    }
+
+    private String localDateToString(LocalDate date) {
+        return date.format(DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
+
+    private LocalDate stringToLocalDate(String date) {
+        return LocalDate.parse(date, DateTimeFormatter.ofPattern("yyyy.MM.dd"));
+    }
 }

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Room.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Room.java
@@ -1,0 +1,2 @@
+package com.firefighter.aenitto.domain;public class Room {
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/RoomState.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/RoomState.java
@@ -1,2 +1,6 @@
-package com.firefighter.aenitto.domain;public enum RoomState {
+package com.firefighter.aenitto.domain;
+
+public enum RoomState {
+    PRE, PROCESSING, POST
+    ;
 }

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/RoomState.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/RoomState.java
@@ -1,0 +1,2 @@
+package com.firefighter.aenitto.domain;public enum RoomState {
+}

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Token.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Token.java
@@ -21,7 +21,7 @@ public class Token {
     @Column(name = "member_id")
     private Long memberId;
 
-    @Column(name = "refresh_token")
+    @Column
     private String refreshToken;
 
     @Builder

--- a/aenitto/src/main/java/com/firefighter/aenitto/domain/Token.java
+++ b/aenitto/src/main/java/com/firefighter/aenitto/domain/Token.java
@@ -1,0 +1,32 @@
+package com.firefighter.aenitto.domain;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Token {
+    @Id @GeneratedValue(strategy = GenerationType.AUTO)
+    @Column(name = "token_id")
+    private Long id;
+
+    /*
+    실제 mapping x
+     */
+    @Column(name = "member_id")
+    private Long memberId;
+
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
+    @Builder
+    public Token(Long memberId, String refreshToken) {
+        this.memberId = memberId;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/aenitto/src/main/resources/application.yml
+++ b/aenitto/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+
+spring:
+  jpa:
+    hibernate:
+      naming:
+        physical-strategy: com.firefighter.aenitto.common.namingStrategy.SnakeLowerCasePhysicalNamingStrategy

--- a/aenitto/src/test/java/com/firefighter/aenitto/scratch/DatetimeTest.java
+++ b/aenitto/src/test/java/com/firefighter/aenitto/scratch/DatetimeTest.java
@@ -1,0 +1,25 @@
+package com.firefighter.aenitto;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class scratch {
+
+    @DisplayName("String -> LocalDate 테스트")
+    @Test
+    void stringToLocalDateTest() {
+        // given
+        String dateString = "2022.06.30";
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.mm.dd");
+
+        // when
+        LocalDate parse = LocalDate.parse(dateString, dateTimeFormatter);
+
+        // then
+
+    }
+
+}

--- a/aenitto/src/test/java/com/firefighter/aenitto/scratch/DatetimeTest.java
+++ b/aenitto/src/test/java/com/firefighter/aenitto/scratch/DatetimeTest.java
@@ -1,25 +1,40 @@
-package com.firefighter.aenitto;
+package com.firefighter.aenitto.scratch;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.*;
 
 import java.time.LocalDate;
 import java.time.format.DateTimeFormatter;
 
-public class scratch {
+public class DatetimeTest {
 
     @DisplayName("String -> LocalDate 테스트")
     @Test
     void stringToLocalDateTest() {
         // given
         String dateString = "2022.06.30";
-        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.mm.dd");
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
 
         // when
         LocalDate parse = LocalDate.parse(dateString, dateTimeFormatter);
 
         // then
+        assertThat(parse).isEqualTo(LocalDate.now());
+    }
 
+    @DisplayName("LocalDate -> String 테스트")
+    @Test
+    void LocalDateToStringTest() {
+        // given
+        LocalDate now = LocalDate.now();
+        DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+
+        // when
+        String format = now.format(dateTimeFormatter);
+
+        // then
+        assertThat(format).isEqualTo("2022.06.30");
     }
 
 }


### PR DESCRIPTION
- 일단 draw.io에 반영된 것까지는 구현함
## 변경사항
- `IndividualMission` 테이블에 fullfilledAt 필드 추가
    -  fulfilled 필드가 있으면 언제 완료되었는지도 있어야 하지 않을까 해서 
- `MemberRoom` 테이블의 characterUrl -> colorIdx로 변경
    - 이미지 결정인자가 색상인 것 같아서 colorIdx로 
- `Message` 테이블에 read 필드 추가 
    - 쪽지 읽었는지 확인 

