### PR TITLE
[Feat] 개별미션 생성 시점 변경 

### DIFF
--- a/src/main/java/com/firefighter/aenitto/missions/service/MissionServiceImpl.java
+++ b/src/main/java/com/firefighter/aenitto/missions/service/MissionServiceImpl.java
@@ -76,7 +76,6 @@ public class MissionServiceImpl implements MissionService {
     }
 
     @Override
-    @Transactional
     public void setInitialIndividualMission(MemberRoom memberRoom) {
         Mission mission = missionRepository.findRandomMission(MissionType.INDIVIDUAL)
                 .orElseThrow(MissionEmptyException::new);

--- a/src/main/java/com/firefighter/aenitto/rooms/service/RoomServiceImpl.java
+++ b/src/main/java/com/firefighter/aenitto/rooms/service/RoomServiceImpl.java
@@ -78,7 +78,6 @@ public class RoomServiceImpl implements RoomService {
                 .build();
 
         memberRoom.setMemberRoom(member, room);
-        missionService.setInitialIndividualMission(memberRoom);
         return roomRepository.saveRoom(room).getId();
     }
 
@@ -115,7 +114,6 @@ public class RoomServiceImpl implements RoomService {
 
         MemberRoom memberRoom = request.toEntity();
         memberRoom.setMemberRoom(member, findRoom);
-        missionService.setInitialIndividualMission(memberRoom);
 
         return roomId;
     }

--- a/src/main/java/com/firefighter/aenitto/rooms/service/RoomServiceImpl.java
+++ b/src/main/java/com/firefighter/aenitto/rooms/service/RoomServiceImpl.java
@@ -205,6 +205,10 @@ public class RoomServiceImpl implements RoomService {
         // 참여인원에 대하여 Relation 생성
         Relation.createRelations(room.getMemberRooms(), room);
 
+        // 참여인원에 대하여 individual Mission 생성
+        room.getMemberRooms().stream()
+                .forEach(missionService::setInitialIndividualMission);
+
         // RoomState 수정
         room.setState(RoomState.PROCESSING);
     }

--- a/src/test/java/com/firefighter/aenitto/rooms/integration/RoomIntegrationTest.java
+++ b/src/test/java/com/firefighter/aenitto/rooms/integration/RoomIntegrationTest.java
@@ -55,10 +55,7 @@ public class RoomIntegrationTest extends IntegrationTest {
 
         flushAndClear();
         Member member = em.find(Member.class, UUID.fromString("f383cdb3-a871-4410-b146-fb1f7b447b9e"));
-        MemberRoom memberRoom = member.getMemberRooms().get(0);
-
-        assertThat(memberRoom.getIndividualMissions()).hasSize(1);
-        assertThat(memberRoom.getIndividualMissions().get(0).getMission().getContent()).isEqualTo("미션2");
+        assertThat(member.getMemberRooms()).hasSize(1);
     }
 
     @DisplayName("초대코드 검증 -> 성공")
@@ -109,8 +106,7 @@ public class RoomIntegrationTest extends IntegrationTest {
                 .findFirst()
                 .orElseThrow(RuntimeException::new);
 
-        assertThat(findMemberRoom.getIndividualMissions()).hasSize(1);
-        assertThat(findMemberRoom.getIndividualMissions().get(0).getMission().getContent()).isEqualTo("미션2");
+        assertThat(findMemberRoom).isNotNull();
     }
 
     @Sql("classpath:room.sql")

--- a/src/test/java/com/firefighter/aenitto/rooms/integration/RoomIntegrationTest.java
+++ b/src/test/java/com/firefighter/aenitto/rooms/integration/RoomIntegrationTest.java
@@ -32,7 +32,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 @WithMockCustomMember
 public class RoomIntegrationTest extends IntegrationTest {
-    private Room room;
+    private static final UUID MOCK_USER_ID = UUID.fromString("f383cdb3-a871-4410-b146-fb1f7b447b9e");
 
     @Sql({
             SqlPath.ROOM_PARTICIPATE
@@ -54,7 +54,7 @@ public class RoomIntegrationTest extends IntegrationTest {
 
 
         flushAndClear();
-        Member member = em.find(Member.class, UUID.fromString("f383cdb3-a871-4410-b146-fb1f7b447b9e"));
+        Member member = em.find(Member.class, MOCK_USER_ID);
         assertThat(member.getMemberRooms()).hasSize(1);
     }
 
@@ -101,7 +101,7 @@ public class RoomIntegrationTest extends IntegrationTest {
                                 " WHERE mr.room.id = :roomId" +
                                 " AND mr.member.id = :memberId", MemberRoom.class)
                 .setParameter("roomId", 100L)
-                .setParameter("memberId", UUID.fromString("f383cdb3-a871-4410-b146-fb1f7b447b9e"))
+                .setParameter("memberId", MOCK_USER_ID)
                 .getResultStream()
                 .findFirst()
                 .orElseThrow(RuntimeException::new);
@@ -537,7 +537,7 @@ public class RoomIntegrationTest extends IntegrationTest {
         Room findRoom = em.find(Room.class, roomId);
         Optional<MemberRoom> voidMemberRoom
                 = findRoom.getMemberRooms().stream()
-                .filter(memberRoom -> memberRoom.getMember().getId() == UUID.fromString("f383cdb3-a871-4410-b146-fb1f7b447b9e"))
+                .filter(memberRoom -> memberRoom.getMember().getId() == MOCK_USER_ID)
                 .findFirst();
 
         assertThat(findRoom.getMemberRooms()).hasSize(4);

--- a/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
+++ b/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
@@ -93,35 +93,28 @@ public class RoomServiceTest {
 
     @BeforeEach
     void setup() {
-        room1 = roomFixture1();
-        room2 = roomFixture2();
-
-        room3 = roomFixture2();
-        member = memberFixture();
         currentUserDetails = CURRENT_USER_DETAILS;
 
+        room1 = roomFixture1();
+        room2 = roomFixture2();
         room3 = roomFixture3();
         room4 = roomFixture4();
         room5 = roomFixture5();
 
+        member = memberFixture();
         member1 = memberFixture();
         member2 = memberFixture2();
         member3 = memberFixture3();
         member4 = memberFixture4();
         member5 = memberFixture5();
 
-        memberRoom = memberRoomFixture1(member, room1);
+//        memberRoom = memberRoomFixture1(member, room1);
         memberRoom1 = memberRoomFixture1(member, room3);
         memberRoom2 = memberRoomFixture2(member2, room3);
         memberRoom3 = memberRoomFixture3(member3, room3);
 
-
-        memberRoom = memberRoomFixture1(member1, room1);
-
         mission1 = MissionFixture.missionFixture2_Individual();
         individualMission1 = individualMissionFixture1();
-
-        currentUserDetails = CURRENT_USER_DETAILS;
     }
 
     @DisplayName("방 생성 성공")
@@ -583,25 +576,29 @@ public class RoomServiceTest {
     void startAenitto_success() {
         // given
         final Long roomId = 1L;
-        ReflectionTestUtils.setField(memberRoom, "admin", true);
-        room1.setState(RoomState.PRE);
+        memberRoom1 = RoomFixture.memberRoomFixture1(member1, room1);
         memberRoom2 = RoomFixture.memberRoomFixture2(member2, room1);
         memberRoom3 = RoomFixture.memberRoomFixture3(member3, room1);
         memberRoom4 = RoomFixture.memberRoomFixture4(member4, room1);
         memberRoom5 = RoomFixture.memberRoomFixture5(member5, room1);
+        ReflectionTestUtils.setField(memberRoom1, "admin", true);
+        room1.setState(RoomState.PRE);
 
         // when
         when(roomRepository.findMemberRoomById(any(UUID.class), anyLong()))
-                .thenReturn(Optional.of(memberRoom));
+                .thenReturn(Optional.of(memberRoom1));
+        doNothing().when(missionService).setInitialIndividualMission(any(MemberRoom.class));
         target.startAenitto(member1, roomId);
 
         // then
-        assertThat(room1.getRelations().size()).isEqualTo(6);
+        assertThat(room1.getRelations().size()).isEqualTo(5);
         assertThat(room1.getRelations().get(0).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(1).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(2).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(3).getManittee()).isNotNull();
         assertThat(room1.getRelations().get(4).getManittee()).isNotNull();
+
+        verify(missionService, times(5)).setInitialIndividualMission(any(MemberRoom.class));
     }
 
 

--- a/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
+++ b/src/test/java/com/firefighter/aenitto/rooms/service/RoomServiceTest.java
@@ -136,7 +136,6 @@ public class RoomServiceTest {
                 .thenReturn(Optional.empty());
         when(roomRepository.saveRoom(any(Room.class)))
                 .thenReturn(room1);
-        doNothing().when(missionService).setInitialIndividualMission(any(MemberRoom.class));
 
         // given
         CreateRoomRequest createRoomRequest = CreateRoomRequest.builder()
@@ -152,7 +151,6 @@ public class RoomServiceTest {
         // then
         assertThat(roomId).isEqualTo(1L);
         verify(roomRepository, times(1)).saveRoom(any(Room.class));
-        verify(missionService, times(1)).setInitialIndividualMission(any(MemberRoom.class));
     }
 
     @DisplayName("초대코드 검증 - 실패 (초대코드 존재하지 않음)")
@@ -289,7 +287,6 @@ public class RoomServiceTest {
                 .thenReturn(Optional.empty());
         when(roomRepository.findRoomById(anyLong()))
                 .thenReturn(Optional.of(room1));
-        doNothing().when(missionService).setInitialIndividualMission(any(MemberRoom.class));
 
         // given
         final ParticipateRoomRequest request = RoomRequestDtoBuilder.participateRoomRequest();
@@ -302,7 +299,6 @@ public class RoomServiceTest {
 
         verify(roomRepository, times(1)).findMemberRoomById(any(UUID.class), anyLong());
         verify(roomRepository, times(1)).findRoomById(anyLong());
-        verify(missionService, times(1)).setInitialIndividualMission(any(MemberRoom.class));
     }
 
     @DisplayName("방 상태 확인 - 실패 (참여 중인 방 x)")


### PR DESCRIPTION
#115 
- (As Is) 방 생성 / 방 참가 시 생성 
- (To Be) 방 시작시 일괄적으로 생성 

추가적으로 RoomServiceTest 리팩토링 
- 무분별하게 초기화된 객체 엔티티 정리 
  - MemberRoom의 경우 앞으로 BeforeEach로 초기화 하지 않고 각 테스트 유닛에서 필요할 때마다 직접 할당하여 이용
- 각 객체 엔티티는 끝에 붙인 숫자로 구분 (숫자 없이 선언된 객체 삭제)